### PR TITLE
Fix query panic on GetNextTask()

### DIFF
--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -70,7 +70,7 @@ func GetNextTask() Task {
 		panic(err.Error())
 	}
 
-	results, err := db.Query("SELECT * FROM task WHERE status = 0 ORDER BY created ASC LIMIT 1;")
+	results, err := db.Query("SELECT id, task, args, status, result, created, updated FROM task WHERE status = 0 ORDER BY created ASC LIMIT 1;")
 
 	// if there is an error inserting, handle it
 	if err != nil {


### PR DESCRIPTION
Trying to execute a stop task was producing a strange error:

```
panic: sql: Scan error on column index 6, name "result": converting NULL to string is unsupported

goroutine 1 [running]:
github.com/edgebox-iot/edgeboxctl/internal/tasks.GetNextTask(0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        github.com/edgebox-iot/edgeboxctl/internal/tasks/tasks.go:87 +0x1f4
main.systemIterator(0x28104c8, 0x1)
        github.com/edgebox-iot/edgeboxctl/cmd/edgeboxctl/main.go:116 +0x78
main.main()
        github.com/edgebox-iot/edgeboxctl/cmd/edgeboxctl/main.go:70 +0x268
```

This was not happening before, but I researched what could be the cause, [found this which pretty much suggest we use sql.NullString](https://stackoverflow.com/questions/44891030/scan-error-unsupported-scan-storing-driver-value-type-nil-into-type-string) (which we already do). 

Still found interesting their suggestion to just not use null at all if possible haha 😎 

**EDIT: Naming the columns in the query solved the problem :)** 