### PR TITLE
Enable codecov

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       run: make build
     - name: Test
       run: make test-with-coverage
-    # - uses: codecov/codecov-action@v1
-    #   with:
-    #     token: ${{ secrets.CODECOV_TOKEN }}
-    #     files: coverage.out
+    - uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: coverage.out

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,3 @@
-codecov:
-  require_ci_to_pass: no
-
 comment: false
+github_checks:
+  annotations: false


### PR DESCRIPTION
Previously it was alerting when coverage dropped. This enables us to track without flagging on PRs