### PR TITLE
Add service file and install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,3 +33,10 @@ test:
 
 test-with-coverage:
 	go test -tags=unit -timeout=600s -v ./... -coverprofile=coverage.out
+
+install: build-cloud
+	cp ./bin/edgeboxctl /usr/local/bin/edgeboxctl
+	cp ./edgeboxctl/edgeboxctl.service /lib/systemd/system/edgeboxctl.service
+	systemctl daemon-reload
+	@echo "Edgeboxctl installed successfully"
+	@echo "To start edgeboxctl run: systemctl start edgeboxctl"

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,14 @@ test:
 test-with-coverage:
 	go test -tags=unit -timeout=600s -v ./... -coverprofile=coverage.out
 
-install: build-cloud
+install-cloud: build-cloud
+	cp ./bin/edgeboxctl /usr/local/bin/edgeboxctl
+	cp ./edgeboxctl/edgeboxctl.service /lib/systemd/system/edgeboxctl.service
+	systemctl daemon-reload
+	@echo "Edgeboxctl installed successfully"
+	@echo "To start edgeboxctl run: systemctl start edgeboxctl"
+
+install-prod: build-prod
 	cp ./bin/edgeboxctl /usr/local/bin/edgeboxctl
 	cp ./edgeboxctl/edgeboxctl.service /lib/systemd/system/edgeboxctl.service
 	systemctl daemon-reload

--- a/edgeboxctl.service
+++ b/edgeboxctl.service
@@ -1,0 +1,29 @@
+[Unit]
+Description=Edgebox Control Module Service
+ConditionPathExists=/home/system/
+After=network.target
+ 
+[Service]
+Type=simple
+User=root
+Group=root
+LimitNOFILE=1024
+
+Restart=on-failure
+RestartSec=10
+startLimitIntervalSec=60
+
+WorkingDirectory=/home/system/components/edgeboxctl
+ExecStart=edgeboxctl --name=edgebox-cloud
+
+# make sure log directory exists and owned by syslog
+PermissionsStartOnly=true
+ExecStartPre=/bin/mkdir -p /var/log/edgeboxctl
+ExecStartPre=/bin/chown root:root /var/log/edgeboxctl
+ExecStartPre=/bin/chmod 755 /var/log/edgeboxctl
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=edgeboxctl
+ 
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Adds edgeboxctl.service file (configuration for systemd)
- Adds `make install` command: Builds for `amd64`, copies binary to `/usr/local/bin/` folder, adds systemd, reloads deamon)

Possible improvements: Command could build both supported arch if argument is passed